### PR TITLE
로그인폼 & 유저 정보 입력 폼

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,8 @@
       "name": "frontend",
       "version": "0.1.0",
       "dependencies": {
+        "@hookform/resolvers": "^4.1.2",
+        "@radix-ui/react-label": "^2.1.2",
         "@radix-ui/react-slot": "^1.1.2",
         "@radix-ui/react-tooltip": "^1.1.8",
         "class-variance-authority": "^0.7.1",
@@ -16,8 +18,10 @@
         "next": "15.1.7",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
+        "react-hook-form": "^7.54.2",
         "tailwind-merge": "^3.0.2",
-        "tailwindcss-animate": "^1.0.7"
+        "tailwindcss-animate": "^1.0.7",
+        "zod": "^3.24.2"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
@@ -204,6 +208,17 @@
       "version": "0.2.9",
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.9.tgz",
       "integrity": "sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg=="
+    },
+    "node_modules/@hookform/resolvers": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-4.1.2.tgz",
+      "integrity": "sha512-wl6H9c9wLOZMJAqGLEVKzbCkxJuV+BYuLFZFCQtCwMe0b3qQk4kUBd/ZAj13SwcSqcx86rCgSCyngQfmA6DOWg==",
+      "dependencies": {
+        "@standard-schema/utils": "^0.3.0"
+      },
+      "peerDependencies": {
+        "react-hook-form": "^7.0.0"
+      }
     },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
@@ -949,6 +964,28 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-label": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-label/-/react-label-2.1.2.tgz",
+      "integrity": "sha512-zo1uGMTaNlHehDyFQcDZXRJhUPDuukcnHz0/jnrup0JA6qL+AFpAnty+7VKa9esuU5xTblAZzTGYJKSKaBxBhw==",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.0.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-popper": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.2.2.tgz",
@@ -1232,6 +1269,11 @@
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.10.5.tgz",
       "integrity": "sha512-kkKUDVlII2DQiKy7UstOR1ErJP8kUKAQ4oa+SQtM0K+lPdmmjj0YnnxBgtTVYH7mUKtbsxeFC9y0AmK7Yb78/A==",
       "dev": true
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g=="
     },
     "node_modules/@swc/counter": {
       "version": "0.1.3",
@@ -4642,6 +4684,21 @@
         "react": "^18.3.1"
       }
     },
+    "node_modules/react-hook-form": {
+      "version": "7.54.2",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.54.2.tgz",
+      "integrity": "sha512-eHpAUgUjWbZocoQYUHposymRb4ZP6d0uwUnooL2uOybA9/3tPUvoAKqEWK1WaSiTxxOfTpffNZP7QwlnM3/gEg==",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
+      }
+    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -5889,6 +5946,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.24.2",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.2.tgz",
+      "integrity": "sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,6 +9,8 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@hookform/resolvers": "^4.1.2",
+    "@radix-ui/react-label": "^2.1.2",
     "@radix-ui/react-slot": "^1.1.2",
     "@radix-ui/react-tooltip": "^1.1.8",
     "class-variance-authority": "^0.7.1",
@@ -17,8 +19,10 @@
     "next": "15.1.7",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-hook-form": "^7.54.2",
     "tailwind-merge": "^3.0.2",
-    "tailwindcss-animate": "^1.0.7"
+    "tailwindcss-animate": "^1.0.7",
+    "zod": "^3.24.2"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/frontend/src/app/auth/_components/login-form.tsx
+++ b/frontend/src/app/auth/_components/login-form.tsx
@@ -1,0 +1,103 @@
+'use client';
+
+import { Header } from '@/components/header';
+import { Button } from '@/components/ui/button';
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form';
+import { Input } from '@/components/ui/input';
+import { cn } from '@/lib/utils';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+
+const LoginSchema = z.object({
+  email: z.string().email({
+    message: '유효하지 않은 이메일 형식이다부기.',
+  }),
+  password: z.string().min(1, {
+    message: '비밀번호를 입력해라부기.',
+  }),
+});
+
+export const LoginForm = () => {
+  const form = useForm<z.infer<typeof LoginSchema>>({
+    resolver: zodResolver(LoginSchema),
+    defaultValues: {
+      email: '',
+      password: '',
+    },
+  });
+
+  const onSubmit = (values: z.infer<typeof LoginSchema>) => {
+    console.log(values);
+  };
+
+  return (
+    <div className="max-w-md flex flex-col items-start m-auto">
+      <Header title="로그인이다부기!" />
+      <Form {...form}>
+        <form
+          onSubmit={form.handleSubmit(onSubmit)}
+          className="mt-[30px] space-y-9"
+        >
+          <FormField
+            control={form.control}
+            name="email"
+            render={({ field }) => (
+              <FormItem className="relative h-[63px]">
+                <FormLabel className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground text-md">
+                  이름
+                </FormLabel>
+                <FormControl>
+                  <Input
+                    {...field}
+                    disabled={false}
+                    placeholder="꾸북스딱스꾸부기"
+                    className={cn(field.value && 'bg-[#F7FFE5]')}
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="password"
+            render={({ field }) => (
+              <FormItem className="relative h-[63px]">
+                <FormLabel className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground text-md">
+                  비밀번호
+                </FormLabel>
+                <FormControl>
+                  <Input
+                    {...field}
+                    type="password"
+                    disabled={false}
+                    className={cn(field.value && 'bg-[#F7FFE5]')}
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <Button
+            type="submit"
+            variant="main"
+            size="main"
+            className="mx-auto"
+            disabled={false}
+          >
+            로그인하기
+          </Button>
+        </form>
+      </Form>
+    </div>
+  );
+};

--- a/frontend/src/app/auth/_components/login-form.tsx
+++ b/frontend/src/app/auth/_components/login-form.tsx
@@ -87,13 +87,7 @@ export const LoginForm = () => {
             )}
           />
 
-          <Button
-            type="submit"
-            variant="main"
-            size="main"
-            className="mx-auto"
-            disabled={false}
-          >
+          <Button type="submit" variant="main" size="main" disabled={false}>
             로그인하기
           </Button>
         </form>

--- a/frontend/src/app/auth/login/page.tsx
+++ b/frontend/src/app/auth/login/page.tsx
@@ -1,0 +1,7 @@
+import { LoginForm } from '../_components/login-form';
+
+const Page = () => {
+  return <LoginForm />;
+};
+
+export default Page;

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -118,4 +118,17 @@ body,
   body {
     @apply bg-background text-foreground;
   }
+
+  /* 브라우저의 기본 autoFill 스타일 제거 */
+  input:-webkit-autofill {
+    box-shadow: 0 0 0px 1000px #f7ffe5 inset !important;
+    -webkit-text-fill-color: #000 !important;
+  }
+
+  input:-webkit-autofill:focus {
+    box-shadow:
+      0 0 0px 1000px #f7ffe5 inset,
+      0 0 0 2px #93d400 !important;
+    border-color: #93d400 !important;
+  }
 }

--- a/frontend/src/app/onboarding/_components/body-part-selector.tsx
+++ b/frontend/src/app/onboarding/_components/body-part-selector.tsx
@@ -19,7 +19,7 @@ export const BodyPartSelector = () => {
   };
 
   return (
-    <div className="max-w-md mt-[72px] px-5 flex flex-col items-start m-auto">
+    <div className="max-w-md flex flex-col items-start m-auto">
       <div className="flex items-end gap-2">
         <Image
           src={

--- a/frontend/src/app/onboarding/_components/user-info-form.tsx
+++ b/frontend/src/app/onboarding/_components/user-info-form.tsx
@@ -1,0 +1,137 @@
+'use client';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form';
+import { Input } from '@/components/ui/input';
+import { Header } from '@/components/header';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+import { Textarea } from '@/components/ui/textarea';
+
+const isNumberRegex = /^[0-9]*$/;
+const FormSchema = z.object({
+  age: z
+    .string()
+    .regex(isNumberRegex, { message: '숫자만 써달라부기!' })
+    .min(1, { message: '나이 알려주라부기 ' })
+    .max(3, { message: '우리 할머니보다 연세 많다부기..' }),
+  job: z
+    .string()
+    .min(1, { message: '가족이 돼주라 내 집이 돼주라 직업 알려주라부기.' })
+    .max(20, { message: '20자 이내로 써달라부기' }),
+  dailyRoutine: z.string().min(10, { message: '조금 더 알려주라부기..' }),
+});
+
+export const UserInfoForm = () => {
+  const form = useForm<z.infer<typeof FormSchema>>({
+    resolver: zodResolver(FormSchema),
+    defaultValues: {
+      age: '',
+      job: '',
+      dailyRoutine: '',
+    },
+    mode: 'onChange',
+  });
+
+  const onSubmit = (values: z.infer<typeof FormSchema>) => {
+    console.log(values);
+  };
+
+  return (
+    <div className="max-w-md flex flex-col items-start m-auto">
+      <Header title="본인 정보를 입력해라부기" />
+      <Form {...form}>
+        <form
+          onSubmit={form.handleSubmit(onSubmit)}
+          className="mt-[30px] space-y-9"
+        >
+          <FormField
+            control={form.control}
+            name="age"
+            render={({ field }) => (
+              <FormItem className="relative h-[63px]">
+                <FormLabel className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground text-md">
+                  나이
+                </FormLabel>
+                <FormControl>
+                  <Input
+                    {...field}
+                    disabled={false}
+                    className={cn(field.value && 'bg-[#F7FFE5]')}
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="job"
+            render={({ field }) => (
+              <FormItem className="relative h-[63px]">
+                <FormLabel className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground text-md">
+                  직업
+                </FormLabel>
+                <FormControl>
+                  <Input
+                    {...field}
+                    disabled={false}
+                    className={cn(field.value && 'bg-[#F7FFE5]')}
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="dailyRoutine"
+            render={({ field }) => (
+              <FormItem className="relative h-fit">
+                <FormLabel className="absolute left-3 top-2 text-muted-foreground text-md">
+                  생활패턴
+                </FormLabel>
+                <FormControl>
+                  <Textarea
+                    className={cn('resize-none', field.value && 'bg-[#F7FFE5]')}
+                    {...field}
+                  />
+                </FormControl>
+                <FormDescription>
+                  하루 일상 루틴, 습관, 질병 이력등 너의 상태를 자세히 알려주면
+                  <br /> 너에 맞는 스트레칭을 추천할 수 있다부기!
+                </FormDescription>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <Button
+            type="submit"
+            variant="main"
+            size="main"
+            // disabled={
+            //   !form.watch('age') ||
+            //   !form.watch('job') ||
+            //   !form.watch('dailyRoutine')
+            // }
+            disabled={!form.formState.isValid}
+          >
+            다 입력했어요
+          </Button>
+        </form>
+      </Form>
+    </div>
+  );
+};

--- a/frontend/src/app/onboarding/page.tsx
+++ b/frontend/src/app/onboarding/page.tsx
@@ -1,7 +1,9 @@
 import { BodyPartSelector } from './_components/body-part-selector';
+import { UserInfoForm } from './_components/user-info-form';
 
 const Page = () => {
-  return <BodyPartSelector />;
+  // return <BodyPartSelector />;
+  return <UserInfoForm />;
 };
 
 export default Page;

--- a/frontend/src/components/header.tsx
+++ b/frontend/src/components/header.tsx
@@ -1,0 +1,23 @@
+import Image from 'next/image';
+
+interface Props {
+  title: string;
+}
+
+export const Header = ({ title }: Props) => {
+  return (
+    <div className="flex items-end gap-2">
+      <Image
+        src="/assets/bugi-head.png"
+        alt="메인 캐릭터 부기 이미지"
+        width={50}
+        height={40}
+      />
+      <div>
+        <p className="w-fit text-sm bg-[#D8FF7F] py-2 px-3 rounded-md rounded-bl-none">
+          {title}
+        </p>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -25,7 +25,7 @@ const buttonVariants = cva(
         sm: 'h-9 rounded-md px-3',
         lg: 'h-11 rounded-md px-8',
         icon: 'h-10 w-10',
-        main: 'w-[339px] h-[54px]',
+        main: 'w-full h-[54px]',
       },
     },
     defaultVariants: {

--- a/frontend/src/components/ui/form.tsx
+++ b/frontend/src/components/ui/form.tsx
@@ -1,0 +1,178 @@
+"use client"
+
+import * as React from "react"
+import * as LabelPrimitive from "@radix-ui/react-label"
+import { Slot } from "@radix-ui/react-slot"
+import {
+  Controller,
+  ControllerProps,
+  FieldPath,
+  FieldValues,
+  FormProvider,
+  useFormContext,
+} from "react-hook-form"
+
+import { cn } from "@/lib/utils"
+import { Label } from "@/components/ui/label"
+
+const Form = FormProvider
+
+type FormFieldContextValue<
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>
+> = {
+  name: TName
+}
+
+const FormFieldContext = React.createContext<FormFieldContextValue>(
+  {} as FormFieldContextValue
+)
+
+const FormField = <
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>
+>({
+  ...props
+}: ControllerProps<TFieldValues, TName>) => {
+  return (
+    <FormFieldContext.Provider value={{ name: props.name }}>
+      <Controller {...props} />
+    </FormFieldContext.Provider>
+  )
+}
+
+const useFormField = () => {
+  const fieldContext = React.useContext(FormFieldContext)
+  const itemContext = React.useContext(FormItemContext)
+  const { getFieldState, formState } = useFormContext()
+
+  const fieldState = getFieldState(fieldContext.name, formState)
+
+  if (!fieldContext) {
+    throw new Error("useFormField should be used within <FormField>")
+  }
+
+  const { id } = itemContext
+
+  return {
+    id,
+    name: fieldContext.name,
+    formItemId: `${id}-form-item`,
+    formDescriptionId: `${id}-form-item-description`,
+    formMessageId: `${id}-form-item-message`,
+    ...fieldState,
+  }
+}
+
+type FormItemContextValue = {
+  id: string
+}
+
+const FormItemContext = React.createContext<FormItemContextValue>(
+  {} as FormItemContextValue
+)
+
+const FormItem = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => {
+  const id = React.useId()
+
+  return (
+    <FormItemContext.Provider value={{ id }}>
+      <div ref={ref} className={cn("space-y-2", className)} {...props} />
+    </FormItemContext.Provider>
+  )
+})
+FormItem.displayName = "FormItem"
+
+const FormLabel = React.forwardRef<
+  React.ElementRef<typeof LabelPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root>
+>(({ className, ...props }, ref) => {
+  const { error, formItemId } = useFormField()
+
+  return (
+    <Label
+      ref={ref}
+      className={cn(error && "text-destructive", className)}
+      htmlFor={formItemId}
+      {...props}
+    />
+  )
+})
+FormLabel.displayName = "FormLabel"
+
+const FormControl = React.forwardRef<
+  React.ElementRef<typeof Slot>,
+  React.ComponentPropsWithoutRef<typeof Slot>
+>(({ ...props }, ref) => {
+  const { error, formItemId, formDescriptionId, formMessageId } = useFormField()
+
+  return (
+    <Slot
+      ref={ref}
+      id={formItemId}
+      aria-describedby={
+        !error
+          ? `${formDescriptionId}`
+          : `${formDescriptionId} ${formMessageId}`
+      }
+      aria-invalid={!!error}
+      {...props}
+    />
+  )
+})
+FormControl.displayName = "FormControl"
+
+const FormDescription = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => {
+  const { formDescriptionId } = useFormField()
+
+  return (
+    <p
+      ref={ref}
+      id={formDescriptionId}
+      className={cn("text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  )
+})
+FormDescription.displayName = "FormDescription"
+
+const FormMessage = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, children, ...props }, ref) => {
+  const { error, formMessageId } = useFormField()
+  const body = error ? String(error?.message) : children
+
+  if (!body) {
+    return null
+  }
+
+  return (
+    <p
+      ref={ref}
+      id={formMessageId}
+      className={cn("text-sm font-medium text-destructive", className)}
+      {...props}
+    >
+      {body}
+    </p>
+  )
+})
+FormMessage.displayName = "FormMessage"
+
+export {
+  useFormField,
+  Form,
+  FormItem,
+  FormLabel,
+  FormControl,
+  FormDescription,
+  FormMessage,
+  FormField,
+}

--- a/frontend/src/components/ui/input.tsx
+++ b/frontend/src/components/ui/input.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react';
+
+import { cn } from '@/lib/utils';
+
+const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<'input'>>(
+  ({ className, type, ...props }, ref) => {
+    return (
+      <input
+        type={type}
+        className={cn(
+          'flex h-[63px] w-full rounded-md border border-[#E5FFA9] bg-background pr-2 pl-[100px] py-2 text-lg file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-[#93D400] focus:border-[#93D400] disabled:cursor-not-allowed disabled:opacity-50',
+          className,
+        )}
+        ref={ref}
+        {...props}
+      />
+    );
+  },
+);
+Input.displayName = 'Input';
+
+export { Input };

--- a/frontend/src/components/ui/label.tsx
+++ b/frontend/src/components/ui/label.tsx
@@ -1,0 +1,26 @@
+"use client"
+
+import * as React from "react"
+import * as LabelPrimitive from "@radix-ui/react-label"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const labelVariants = cva(
+  "text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+)
+
+const Label = React.forwardRef<
+  React.ElementRef<typeof LabelPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root> &
+    VariantProps<typeof labelVariants>
+>(({ className, ...props }, ref) => (
+  <LabelPrimitive.Root
+    ref={ref}
+    className={cn(labelVariants(), className)}
+    {...props}
+  />
+))
+Label.displayName = LabelPrimitive.Root.displayName
+
+export { Label }

--- a/frontend/src/components/ui/textarea.tsx
+++ b/frontend/src/components/ui/textarea.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react';
+
+import { cn } from '@/lib/utils';
+
+const Textarea = React.forwardRef<
+  HTMLTextAreaElement,
+  React.ComponentProps<'textarea'>
+>(({ className, ...props }, ref) => {
+  return (
+    <textarea
+      className={cn(
+        'flex h-[100px] w-full rounded-md border border-[#E5FFA9] bg-background px-3 pb-2 pt-[30px] text-base placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-[#93D400] focus:border-[#93D400] disabled:cursor-not-allowed disabled:opacity-50',
+        className,
+      )}
+      ref={ref}
+      {...props}
+    />
+  );
+});
+Textarea.displayName = 'Textarea';
+
+export { Textarea };


### PR DESCRIPTION
### # 1 shadcn-ui Input 컴포넌트 border, outline 색상 변경이 되지 않는 문제
🛠 **우선순위 문제**
`focus-visible:outline-[#93D400]`을 사용했는데, Tailwind의 `focus-visible:outline`이 `border`보다 적용 우선순위가 낮을 수 있음.
`focus-visible:border-[#93D440]`이 적용되지 않는다면, `focus:outline-none`을 추가해서 기본 `outline`을 제거하고 직접 `border`를 제어
```javascript
const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<'input'>>(
  ({ className, type, ...props }, ref) => {
    return (
      <input
        type={type}
        className={cn(
          'flex h-[63px] w-full rounded-md border border-[#E5FFA9] bg-background px-3 py-2 text-xl file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-[#93D400] focus:border-[#93D400] disabled:cursor-not-allowed disabled:opacity-50',
          className,
        )}
        ref={ref}
        {...props}
      />
    );
  }
);
```
- `focus:outline-none` 추가 → 기본 outline을 제거해서 border와 ring이 적용되도록 함.
- `focus:ring-2 focus:ring-[#93D400]` 추가 → border 색상이 focus 시 적용되도록 함.
- `focus:border-[#93D400]` 추가 → border 색상을 명확하게 지정.

### # 2 브라우저의 autoFill 속성 제거
인풋에 입력값을 직접 치지 않고 자동 완성된 값을 선택하면 브라우저의 `autoFill` 속성으로 인해,
인풋의 border와 bg 색상이 브라우저가 지정한 색상으로 변경되는 문제

```javascript
// globals.css
 /* 브라우저의 기본 autoFill 스타일 제거 */
  input:-webkit-autofill {
    box-shadow: 0 0 0px 1000px #f7ffe5 inset !important;
    -webkit-text-fill-color: #000 !important;
  }

  input:-webkit-autofill:focus {
    box-shadow:
      0 0 0px 1000px #f7ffe5 inset,
      0 0 0 2px #93d400 !important;
    border-color: #93d400 !important;
  }
```

### # 3 input에 입력 값이 채워지면 bg 색상 변경하기
`react-hook-form`의 `field.value`로 관리
```javascript
<FormField
      control={form.control}
      name="job"
      render={({ field }) => (
        <FormItem className="relative h-[63px]">
          <FormLabel className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground text-md">
            직업
          </FormLabel>
          <FormControl>
            <Input
              {...field}
              disabled={false}
              className={cn(field.value && 'bg-[#F7FFE5]')}
            />
          </FormControl>
          <FormMessage />
        </FormItem>
      )}
    />
```

### # 4 값이 유효한지에 따라 버튼 disabled 처리
`react-hook-form`의 `formState.isValid` 활용
`mode: onChage` 추가
- 기존에는 `useWatch`를 통해 값이 변경될 때마다 감지하는 방법을 썼지만, 이번에는 `useWatch`
없이 다른 방법 활용! 

```javascript
const { handleSubmit, formState } = useForm<z.infer<typeof FormSchema>>({
  resolver: zodResolver(FormSchema),
  defaultValues: {
    age: '',
    job: '',
    dailyRoutine: '',
  },
  mode: 'onChange', // 실시간 검증
});

return (
  <button type="submit" disabled={!formState.isValid}>
    제출하기
  </button>
);
```
